### PR TITLE
Requirements updated

### DIFF
--- a/admin_tools_stats/requirements.txt
+++ b/admin_tools_stats/requirements.txt
@@ -1,8 +1,8 @@
 Django>=1.3.0
-python-dateutil==1.5
-django-jsonfield==0.6
+python-dateutil>=1.5,<2.0
+django-jsonfield>=0.7.1
 django-qsstats-magic>=0.6.1
 django-chart-tools>=0.2.1
 python-memcached>=1.47
 django-cache-utils
-hg+https://bitbucket.org/izi/django-admin-tools
+django-admin-tools


### PR DESCRIPTION
I fixed requirements:
- django-jsonfield==0.7.1 doesn't produce DeprecationWarning
- django-admin-tools is installed from PYPI
