### PR TITLE
update GitHub account name in setup url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     long_description=read('README.rst'),
     author='Belaid Arezqui',
     author_email='areski@gmail.com',
-    url='http://github.com/Star2Billing/django-admin-tools-stats',
+    url='https://github.com/areski/django-admin-tools-stats',
     include_package_data=True,
     zip_safe=False,
     package_dir={'admin_tools_stats': 'admin_tools_stats'},


### PR DESCRIPTION
s/Star2Billing/areski/

GitHub is 301'ing to the correct URL anyway, so you may not care but I thought I'd let you know just in case. If you find that tiny commits clutter up your git history, please feel free to disregard this PR and just make the update whenever you next touch upon setup... 😄 

Thanks for sharing your code!