### PR TITLE
Travis testing in Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,10 @@ python:
 
 env:
   matrix:
-    - DJANGO_VERSION="Django<1.8"
     - DJANGO_VERSION="Django<1.9"
     - DJANGO_VERSION="Django<1.10"
     - DJANGO_VERSION="Django<1.11"
-    - DJANGO_VERSION="Django<2.0"
-    - DJANGO_VERSION="Django<2.1"
+    - DJANGO_VERSION="--pre Django<2.1"
     - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
 
 cache:
@@ -25,23 +23,23 @@ cache:
 install:
   - pip install coverage coveralls django-coverage-plugin
   - pip install -r requirements.txt
-  - pip install -q "$DJANGO_VERSION"
+  - pip install -q $DJANGO_VERSION
 
 matrix:
   exclude:
-    - python: "3.5"
-      env: DJANGO_VERSION="Django<1.8"
-    - python: "3.3"
-      env: DJANGO_VERSION="Django<1.8"
     - python: "3.3"
       env: DJANGO_VERSION="Django<1.10"
     - python: "3.3"
       env: DJANGO_VERSION="Django<1.11"
+    - python: "2.7"
+      env: DJANGO_VERSION="--pre Django<2.1"
     - python: "3.3"
-      env: DJANGO_VERSION="Django<2.0"
+      env: DJANGO_VERSION="--pre Django<2.1"
+    - python: "2.7"
+      env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
     - python: "3.3"
-      env: DJANGO_VERSION="Django<2.1"
-    - python: "3.3"
+      env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
+    - python: "3.4"
       env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
   allow_failures:
     - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
@@ -50,6 +48,7 @@ before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 
 script:
+    - django-admin --version
     - python -Wall $VIRTUAL_ENV/bin/coverage run setup.py test
 
 after_success:

--- a/demoproject/dashboard.py
+++ b/demoproject/dashboard.py
@@ -11,7 +11,10 @@ And to activate the app index dashboard::
 """
 
 from django.utils.translation import ugettext_lazy as _
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django<2.0
+    from django.core.urlresolvers import reverse
 
 from admin_tools.dashboard import modules, Dashboard, AppIndexDashboard
 from admin_tools.utils import get_admin_site_name

--- a/demoproject/demoproject/settings.py
+++ b/demoproject/demoproject/settings.py
@@ -103,7 +103,6 @@ TEMPLATES = [{
             ('django.template.loaders.cached.Loader', [
                 'django.template.loaders.filesystem.Loader',
                 'django.template.loaders.app_directories.Loader',
-                'django.template.loaders.eggs.Loader',
                 'admin_tools.template_loaders.Loader',
             ]),
         ],
@@ -124,7 +123,6 @@ TEMPLATES = [{
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
-    'django.template.loaders.eggs.Loader',
     'admin_tools.template_loaders.Loader',
 )
 TEMPLATE_CONTEXT_PROCESSORS = (
@@ -145,10 +143,10 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware'
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+MIDDLEWARE = MIDDLEWARE_CLASSES
 
 
 ROOT_URLCONF = 'demoproject.urls'

--- a/demoproject/demoproject/urls.py
+++ b/demoproject/demoproject/urls.py
@@ -14,5 +14,5 @@ urlpatterns = [
     # url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
 
     url(r'^admin_tools/', include('admin_tools.urls')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/demoproject/menu.py
+++ b/demoproject/menu.py
@@ -6,7 +6,10 @@ To activate your custom menu add the following to your settings.py::
     ADMIN_TOOLS_MENU = 'demoproject.menu.CustomMenu'
 """
 
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django<2.0
+    from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from admin_tools.menu import items, Menu


### PR DESCRIPTION
Hi @areski,

this PR configures and fixes Travis testing in Django 2.0rc1. It also removes testing in Django 1.7, which is not working due to incompatibility with djcacheutils and is obsolete.

The "--pre" tag for Django 2.0 should be removed after it's stable version release.