### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,18 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 
 env:
   matrix:
-    - DJANGO_VERSION="Django<1.9"
-    - DJANGO_VERSION="Django<1.10"
-    - DJANGO_VERSION="Django<1.11"
-    - DJANGO_VERSION="--pre Django<2.1"
+    - DJANGO_VERSION="Django>=1.11,<2.0"
+    - DJANGO_VERSION="Django>=2.0,<2.1"
+    - DJANGO_VERSION="Django>=2.1,<2.2"
+    - DJANGO_VERSION="Django>=2.2,<3.0"
+    - DJANGO_VERSION="--pre Django>=3.0,<3.1"
     - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
 
 cache:
@@ -28,21 +30,30 @@ install:
 
 matrix:
   exclude:
-    - python: "3.3"
-      env: DJANGO_VERSION="Django<1.10"
-    - python: "3.3"
-      env: DJANGO_VERSION="Django<1.11"
     - python: "2.7"
-      env: DJANGO_VERSION="--pre Django<2.1"
-    - python: "3.3"
-      env: DJANGO_VERSION="--pre Django<2.1"
+      env: DJANGO_VERSION="Django>=2.0,<2.1"
     - python: "2.7"
-      env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
-    - python: "3.3"
+      env: DJANGO_VERSION="Django>=2.1,<2.2"
+    - python: "2.7"
+      env: DJANGO_VERSION="Django>=2.2,<3.0"
+    - python: "2.7"
+      env: DJANGO_VERSION="--pre Django>=3.0,<3.1"
+    - python: "2.7"
       env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
     - python: "3.4"
       env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
+    - python: "3.4"
+      env: DJANGO_VERSION="--pre Django>=3.0,<3.1"
+    - python: "3.4"
+      env: DJANGO_VERSION="Django>=2.1,<2.2"
+    - python: "3.4"
+      env: DJANGO_VERSION="Django>=2.2,<3.0"
+    - python: "3.5"
+      env: DJANGO_VERSION="--pre Django>=3.0,<3.1"
+    - python: "3.5"
+      env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
   allow_failures:
+    - env: DJANGO_VERSION="--pre Django>=3.0,<3.1"
     - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
 
 before_cache:

--- a/demoproject/demoproject/settings.py
+++ b/demoproject/demoproject/settings.py
@@ -108,6 +108,7 @@ TEMPLATES = [{
         ],
         'context_processors': [
             "django.contrib.auth.context_processors.auth",
+            "django.contrib.messages.context_processors.messages",
             "django.template.context_processors.debug",
             "django.template.context_processors.i18n",
             "django.template.context_processors.media",


### PR DESCRIPTION
The support of older Django versions was dropped in `django-qsstats-magic`. This updates testing to now supported versions of Django and fixes testing configuration for Django 2.2.