### PR TITLE
Related field name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,18 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 
 env:
   matrix:
-    - DJANGO_VERSION="Django<1.9"
-    - DJANGO_VERSION="Django<1.10"
-    - DJANGO_VERSION="Django<1.11"
-    - DJANGO_VERSION="--pre Django<2.1"
+    - DJANGO_VERSION="Django>=1.11,<2.0"
+    - DJANGO_VERSION="Django>=2.0,<2.1"
+    - DJANGO_VERSION="Django>=2.1,<2.2"
+    - DJANGO_VERSION="Django>=2.2,<3.0"
+    - DJANGO_VERSION="--pre Django>=3.0,<3.1"
     - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
 
 cache:
@@ -28,21 +30,30 @@ install:
 
 matrix:
   exclude:
-    - python: "3.3"
-      env: DJANGO_VERSION="Django<1.10"
-    - python: "3.3"
-      env: DJANGO_VERSION="Django<1.11"
     - python: "2.7"
-      env: DJANGO_VERSION="--pre Django<2.1"
-    - python: "3.3"
-      env: DJANGO_VERSION="--pre Django<2.1"
+      env: DJANGO_VERSION="Django>=2.0,<2.1"
     - python: "2.7"
-      env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
-    - python: "3.3"
+      env: DJANGO_VERSION="Django>=2.1,<2.2"
+    - python: "2.7"
+      env: DJANGO_VERSION="Django>=2.2,<3.0"
+    - python: "2.7"
+      env: DJANGO_VERSION="--pre Django>=3.0,<3.1"
+    - python: "2.7"
       env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
     - python: "3.4"
       env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
+    - python: "3.4"
+      env: DJANGO_VERSION="--pre Django>=3.0,<3.1"
+    - python: "3.4"
+      env: DJANGO_VERSION="Django>=2.1,<2.2"
+    - python: "3.4"
+      env: DJANGO_VERSION="Django>=2.2,<3.0"
+    - python: "3.5"
+      env: DJANGO_VERSION="--pre Django>=3.0,<3.1"
+    - python: "3.5"
+      env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
   allow_failures:
+    - env: DJANGO_VERSION="--pre Django>=3.0,<3.1"
     - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
 
 before_cache:

--- a/admin_tools_stats/models.py
+++ b/admin_tools_stats/models.py
@@ -10,11 +10,7 @@
 #
 
 from django.db import models
-from django.core.exceptions import ValidationError
-try:
-    from django.core.exceptions import FieldDoesNotExist
-except ImportError:  # Django == 1.7
-    from django.contrib.contenttypes.admin import FieldDoesNotExist
+from django.core.exceptions import FieldError, ValidationError
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.apps import apps
@@ -108,10 +104,10 @@ class DashboardStats(models.Model):
     model_name = models.CharField(max_length=90, verbose_name=_('model name'),
                                   help_text=_("ex. User"))
     date_field_name = models.CharField(max_length=90, verbose_name=_("date field name"),
-                                       help_text=_("ex. date_joined"))
+                                       help_text=_("ex. date_joined, invitation__invitation_date"))
     operation_field_name = models.CharField(max_length=90, verbose_name=_("Operate field name"),
                                       null=True, blank=True,
-                                      help_text=_("The field you want to aggregate, ex. amount"))
+                                      help_text=_("The field you want to aggregate, ex. amount, salaries__total_income"))
     type_operation_field_name = models.CharField(max_length=90, verbose_name=_("Choose Type operation"),
                                       null=True, blank=True, choices=operation,
                                       help_text=_("choose the type operation what you want to aggregate, ex. Sum"))
@@ -141,14 +137,14 @@ class DashboardStats(models.Model):
 
         try:
             if model and self.operation_field_name:
-                operation_field = model._meta.get_field(self.operation_field_name)
-        except FieldDoesNotExist as e:
+                model.objects.all().query.resolve_ref(self.operation_field_name)
+        except FieldError as e:
             errors['operation_field_name'] = str(e)
 
         try:
             if model and self.date_field_name:
-                date_field = model._meta.get_field(self.date_field_name)
-        except FieldDoesNotExist as e:
+                model.objects.all().query.resolve_ref(self.date_field_name)
+        except FieldError as e:
             errors['date_field_name'] = str(e)
 
         raise ValidationError(errors)

--- a/admin_tools_stats/modules.py
+++ b/admin_tools_stats/modules.py
@@ -120,7 +120,7 @@ class DashboardChart(modules.DashboardModule):
                 }
                 aggregate = operation[conf_data.type_operation_field_name]
 
-            stats = QuerySetStats(model_name.objects.filter(**kwargs),
+            stats = QuerySetStats(model_name.objects.filter(**kwargs).distinct(),
                                   conf_data.date_field_name, aggregate)
             # stats = QuerySetStats(User.objects.filter(is_active=True), 'date_joined')
             today = now()

--- a/demoproject/demoproject/settings.py
+++ b/demoproject/demoproject/settings.py
@@ -108,6 +108,7 @@ TEMPLATES = [{
         ],
         'context_processors': [
             "django.contrib.auth.context_processors.auth",
+            "django.contrib.messages.context_processors.messages",
             "django.template.context_processors.debug",
             "django.template.context_processors.i18n",
             "django.template.context_processors.media",


### PR DESCRIPTION
The validation of operate/date fields was too restrictive. With this PR, it is possible to refer related fields through `__` qualifier. Also the validation message is more helpful now, since it is the Django error message containing possible field choices.