### PR TITLE
(WIP) load charts by Ajax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ dist/
 *.egg-info/*
 *sublime*
 *~
+*.swp
+*.swo

--- a/admin_tools_stats/models.py
+++ b/admin_tools_stats/models.py
@@ -220,15 +220,35 @@ class DashboardStats(models.Model):
                 temp += '</select>'
 
         temp += '<input type="hidden" class="hidden_graph_key" name="graph_key" value="%s">' % self.graph_key
-        temp += 'Aggregation: <select class="chart-input select_box_interval" name="select_box_interval" >'
+
+        temp += 'Scale: <select class="chart-input select_box_interval" name="select_box_interval" >'
         for interval in ('hours', 'days', 'weeks', 'months', 'years'):
             selected_str = 'selected=selected' if interval == 'days' else ''
             temp += '<option class="chart-input" value="' + interval + '" ' + selected_str + '>' + interval + '</option>'
         temp += '</select>'
-        temp += 'Date since: <input class="chart-input select_box_date_since" type="date" name="time_since" value="%s">' % \
+
+        temp += 'Since: <input class="chart-input select_box_date_since" type="date" name="time_since" value="%s">' % \
             (now() - timedelta(days=21)).strftime('%Y-%m-%d')
-        temp += 'Date until: <input class="chart-input select_box_date_since" type="date" name="time_until" value="%s">' % \
+        temp += 'Until: <input class="chart-input select_box_date_since" type="date" name="time_until" value="%s">' % \
             now().strftime('%Y-%m-%d')
+
+        chart_types = (
+            ('discreteBarChart',        'Bar'),
+            ('lineChart',               'Line'),
+            ('multiBarChart',           'Multi Bar'),
+            ('pieChart',                'Pie'),
+            ('stackedAreaChart',        'Stacked Area'),
+            ('multiBarHorizontalChart', 'Multi Bar Horizontal'),
+            ('linePlusBarChart',        'Line Plus Bar'),
+            ('scatterChart',            'Scatter'),
+            ('cumulativeLineChart',     'Cumulative Line'),
+            ('lineWithFocusChart',      'Line With Focus'),
+        )
+        temp += 'Chart: <select class="chart-input select_box_chart_type" name="select_box_chart_type" >'
+        for chart_type_str, chart_type_name in chart_types:
+            selected_str = 'selected=selected' if chart_type_str == 'discreteBarChart' else ''
+            temp += '<option class="chart-input" value="' + chart_type_str + '" ' + selected_str + '>' + chart_type_name + '</option>'
+        temp += '</select>'
 
         return mark_safe(force_text(temp))
 

--- a/admin_tools_stats/modules.py
+++ b/admin_tools_stats/modules.py
@@ -83,6 +83,16 @@ class DashboardChart(modules.DashboardModule):
         super(DashboardChart, self).init_with_context(context)
         request = context['request']
 
+        self.data = []
+        self.prepare_template_data(self.data, self.graph_key, self.select_box_value, self.other_select_box_values)
+
+        if hasattr(self, 'error_message'):
+            messages.add_message(request, messages.ERROR, "%s dashboard: %s" % (self.title, self.error_message))
+
+    def init_with_context_ajax(self, context):
+        super(DashboardChart, self).init_with_context(context)
+        request = context['request']
+
         self.data = self.get_registrations(request.user, self.interval, self.days,
                                            self.graph_key, self.select_box_value)
         self.prepare_template_data(self.data, self.graph_key, self.select_box_value, self.other_select_box_values)
@@ -160,7 +170,7 @@ class DashboardChart(modules.DashboardModule):
 
         self.chart_container = self.interval + '_' + self.graph_key
         # add string into href attr
-        self.id = self.chart_container
+        self.id = self.interval + '__' + self.graph_key
 
         xdata = []
         ydata = []
@@ -199,7 +209,7 @@ def get_dynamic_criteria(graph_key, select_box_value, other_select_box_values):
         for i in conf_data:
             dy_map = i.criteria_dynamic_mapping
             if dy_map:
-                temp = '<select name="select_box_' + graph_key + '" onChange="$(this).closest(\'form\').submit();">'
+                temp = '<select class="dynamic_criteria_select_box" name="select_box_' + graph_key + '" >'
                 for key in dict(dy_map):
                     value = dy_map[key]
                     if key == select_box_value:

--- a/admin_tools_stats/modules.py
+++ b/admin_tools_stats/modules.py
@@ -25,8 +25,6 @@ class DashboardChart(modules.DashboardModule):
     """
     template = 'admin_tools_stats/modules/chart.html'
     days = None
-    chart_height = 300
-    chart_width = '100%'
     require_chart_jscss = False
     extra = {}
 

--- a/admin_tools_stats/modules.py
+++ b/admin_tools_stats/modules.py
@@ -11,25 +11,11 @@
 #
 import warnings
 
-from django.db.models.aggregates import Count, Sum, Avg, Max, Min, StdDev, Variance
-from django.contrib.auth import get_user_model
-from django.apps import apps
-try:  # Python 3
-    from django.utils.encoding import force_text
-except ImportError:  # Python 2
-    from django.utils.encoding import force_unicode as force_text
-from django.contrib import messages
-from django.core.exceptions import FieldError
-from django.utils.safestring import mark_safe
-from qsstats import QuerySetStats
-from cache_utils.decorators import cached
 from admin_tools.dashboard import modules
-from admin_tools_stats.models import DashboardStats
-from datetime import datetime, timedelta
 
-import time
+from django.contrib import messages
 
-from django.utils.timezone import now
+from .models import DashboardStats
 
 
 class DashboardChart(modules.DashboardModule):
@@ -39,18 +25,10 @@ class DashboardChart(modules.DashboardModule):
     """
     template = 'admin_tools_stats/modules/chart.html'
     days = None
-    interval = 'days'
-    tooltip_date_format = "%d %b %Y"
-    interval_dateformat_map = {
-        'months': ("%b %Y", "%b"),
-        'days': ("%d %b %Y", "%a"),
-        'hours': ("%d %b %Y %H:%S", "%H"),
-    }
-    chart_type = 'discreteBarChart'
     chart_height = 300
     chart_width = '100%'
     require_chart_jscss = False
-    extra = dict()
+    extra = {}
 
     model = None
     graph_key = None
@@ -62,174 +40,46 @@ class DashboardChart(modules.DashboardModule):
 
     def __init__(self, *args, **kwargs):
         super(DashboardChart, self).__init__(*args, **kwargs)
-        self.select_box_value = ''
-        self.other_select_box_values = {}
         self.require_chart_jscss = kwargs['require_chart_jscss']
-        self.time_since = kwargs.get('time_since', None)
-        self.time_until = kwargs.get('time_until', None)
-        self.graph_key = kwargs['graph_key']
-        self.title = get_title(self.graph_key)
-        for key in kwargs:
-            if key.startswith('select_box_'):
-                if key == 'select_box_' + self.graph_key:
-                    self.select_box_value = kwargs[key]
-                else:
-                    self.other_select_box_values[key] = kwargs[key]
+        self.title = self.get_title(self.graph_key)
 
     def init_with_context(self, context):
         super(DashboardChart, self).init_with_context(context)
         request = context['request']
 
-        self.data = []
-        self.prepare_template_data(self.data, self.graph_key, self.select_box_value, self.other_select_box_values)
+        self.prepare_module_data(self.graph_key)
+
+        self.form_field = self.get_control_form(self.graph_key)
 
         if hasattr(self, 'error_message'):
             messages.add_message(request, messages.ERROR, "%s dashboard: %s" % (self.title, self.error_message))
 
-    def init_with_context_ajax(self, context):
-        super(DashboardChart, self).init_with_context(context)
-        request = context['request']
-
-        self.data = self.get_registrations(request.user, self.interval,
-                                           self.graph_key, request.GET)
-        self.prepare_template_data(self.data, self.graph_key, self.select_box_value, self.other_select_box_values)
-
-        if hasattr(self, 'error_message'):
-            messages.add_message(request, messages.ERROR, "%s dashboard: %s" % (self.title, self.error_message))
-
-    @cached(60 * 5)
-    def get_registrations(self, user, interval, graph_key, get_params):
-        """ Returns an array with new users count per interval."""
-        try:
-            conf_data = DashboardStats.objects.get(graph_key=graph_key)
-            model_name = apps.get_model(conf_data.model_app_name, conf_data.model_name)
-            kwargs = {}
-            if not user.is_superuser and conf_data.user_field_name:
-                kwargs[conf_data.user_field_name] = user
-            for i in conf_data.criteria.all():
-                # fixed mapping value passed info kwargs
-                if i.criteria_fix_mapping:
-                    for key in i.criteria_fix_mapping:
-                        # value => i.criteria_fix_mapping[key]
-                        kwargs[key] = i.criteria_fix_mapping[key]
-
-                # dynamic mapping value passed info kwargs
-                dynamic_key = "select_box_dynamic_%i" % i.id
-                if dynamic_key in get_params:
-                    if get_params[dynamic_key] != '':
-                        kwargs[i.dynamic_criteria_field_name] = get_params[dynamic_key]
-
-            aggregate = None
-            if conf_data.type_operation_field_name and conf_data.operation_field_name:
-                operation = {
-                    'DistinctCount': Count(conf_data.operation_field_name, distinct=True),
-                    'Count': Count(conf_data.operation_field_name),
-                    'Sum': Sum(conf_data.operation_field_name),
-                    'Avg': Avg(conf_data.operation_field_name),
-                    'StdDev': StdDev(conf_data.operation_field_name),
-                    'Max': Max(conf_data.operation_field_name),
-                    'Min': Min(conf_data.operation_field_name),
-                    'Variance': Variance(conf_data.operation_field_name),
-                }
-                aggregate = operation[conf_data.type_operation_field_name]
-
-            stats = QuerySetStats(model_name.objects.filter(**kwargs).distinct(),
-                                  conf_data.date_field_name, aggregate)
-            # stats = QuerySetStats(User.objects.filter(is_active=True), 'date_joined')
-            return stats.time_series(self.time_since, self.time_until, interval)
-        except (LookupError, FieldError, TypeError) as e:
-            self.error_message = str(e)
-            User = get_user_model()
-            stats = QuerySetStats(
-                User.objects.filter(is_active=True), 'date_joined')
-            return stats.time_series(self.time_since, self.time_until, interval)
-
-    @cached(60 * 5)
-    def prepare_template_data(self, data, graph_key, select_box_value, other_select_box_values):
+    def prepare_module_data(self, graph_key):
         """ Prepares data for template (passed as module attributes) """
-        self.extra = {
-            'x_is_date': True,
-            'tag_script_js': False,
-            'jquery_on_ready': False,
-        }
-
-        if self.interval in self.interval_dateformat_map:
-            self.tooltip_date_format, self.extra['x_axis_format'] = self.interval_dateformat_map[self.interval]
-
         self.chart_container = "chart_container_" + self.graph_key
-        # add string into href attr
-        self.id = self.interval + '_' + self.graph_key
+        self.id = 'chart_' + self.graph_key
 
-        xdata = []
-        ydata = []
-        for data_date in self.data:
-            start_time = int(time.mktime(data_date[0].timetuple()) * 1000)
-            xdata.append(start_time)
-            ydata.append(data_date[1])
+    def get_title(self, graph_key):
+        """Returns graph title"""
+        try:
+            return DashboardStats.objects.get(graph_key=graph_key).graph_title
+        except LookupError as e:
+            self.error_message = str(e)
+            return ''
 
-        extra_serie = {"tooltip": {"y_start": "", "y_end": ""},
-                       "date_format": self.tooltip_date_format}
-
-        self.values = {
-            'x': xdata,
-            'name1': self.interval, 'y1': ydata, 'extra1': extra_serie,
-        }
-
-        self.form_field = get_dynamic_criteria(graph_key, select_box_value, other_select_box_values)
-
-
-@cached(60 * 5)
-def get_title(graph_key):
-    """Returns graph title"""
-    try:
-        return DashboardStats.objects.get(graph_key=graph_key).graph_title
-    except LookupError as e:
-        self.error_message = str(e)
-        return ''
-
-
-@cached(60 * 5)
-def get_dynamic_criteria(graph_key, select_box_value, other_select_box_values):
-    """To get dynamic criteria & return into select box to display on dashboard"""
-    try:
-        temp = ''
-        conf_data = DashboardStats.objects.get(graph_key=graph_key).criteria.all()
-        for i in conf_data:
-            dy_map = i.criteria_dynamic_mapping
-            if dy_map:
-                temp += i.criteria_name + ': <select class="chart-input dynamic_criteria_select_box" name="select_box_dynamic_%i" >' % i.id
-                for key in dict(dy_map):
-                    value = dy_map[key]
-                    if key == select_box_value:
-                        temp += '<option value="' + key + '" selected=selected>' + value + '</option>'
-                    else:
-                        temp += '<option value="' + key + '">' + value + '</option>'
-                temp += '</select>'
-
-        temp += "\n".join(['<input type="hidden" name="%s" value="%s">' % (key, other_select_box_values[key]) for key in other_select_box_values ])
-
-        temp += '<input type="hidden" class="hidden_graph_key" name="graph_key" value="%s">' % graph_key
-        temp += 'Aggregation: <select class="chart-input select_box_interval" name="select_box_interval" >'
-        for interval in ('hours', 'days', 'weeks', 'months', 'years'):
-            selected_str = 'selected=selected' if interval == 'days' else ''
-            temp += '<option class="chart-input" value="' + interval + '" ' + selected_str + '>' + interval + '</option>'
-        temp += '</select>'
-        temp += 'Date since: <input class="chart-input select_box_date_since" type="date" name="time_since" value="%s">' % (now() - timedelta(days=21)).strftime('%Y-%m-%d')
-        temp += 'Date until: <input class="chart-input select_box_date_since" type="date" name="time_until" value="%s">' % now().strftime('%Y-%m-%d')
-
-        return mark_safe(force_text(temp))
-    except LookupError as e:
-        self.error_message = str(e)
-        return ''
+    def get_control_form(self, graph_key):
+        """To get dynamic criteria & return into select box to display on dashboard"""
+        try:
+            dashboard_stats = DashboardStats.objects.get(graph_key=graph_key)
+            return dashboard_stats.get_control_form()
+        except LookupError as e:
+            self.error_message = str(e)
+            return ''
 
 
 def get_active_graph():
     """Returns active graphs"""
-    try:
-        return DashboardStats.objects.filter(is_visible=1)
-    except LookupError as e:
-        self.error_message = str(e)
-        return []
+    return DashboardStats.objects.filter(is_visible=1)
 
 
 class DashboardCharts(DashboardChart):
@@ -238,6 +88,6 @@ class DashboardCharts(DashboardChart):
     def __init__(self, *args, **kwargs):
         warnings.warn(
             "DashboardCharts are not required anymore. Use just DashboardChart instead",
-             PendingDeprecationWarning
+            PendingDeprecationWarning
         )
         super(DashboardCharts, self).__init__(*args, **kwargs)

--- a/admin_tools_stats/templates/admin/index.html
+++ b/admin_tools_stats/templates/admin/index.html
@@ -5,7 +5,7 @@
 {% block extrastyle %}
    {{ block.super }}
    <link media="all" href="{% static 'nvd3/build/nv.d3.css' %}" type="text/css" rel="stylesheet" />
-   <script src="{% static "admin_tools/js/jquery/jquery.min.js" %}"></script>
+   <script src="{% static "admin/js/vendor/jquery/jquery.js" %}"></script>
    <script src="{% static 'd3/d3.js' %}" type="text/javascript"></script>
    <script src="{% static 'nvd3/build/nv.d3.js'%}" type="text/javascript"></script>
    <script src="{% url 'admin-charts' %}" type="text/javascript"></script>

--- a/admin_tools_stats/templates/admin/index.html
+++ b/admin_tools_stats/templates/admin/index.html
@@ -17,6 +17,8 @@
 {% endblock %}
 
 {% block footer %}
-   {% chart_containers %}
+   {% if request.resolver_match.view_name == 'admin:index' %}
+      {% chart_containers %}
+   {% endif %}
    {{ block.super }}
 {% endblock %}

--- a/admin_tools_stats/templates/admin/index.html
+++ b/admin_tools_stats/templates/admin/index.html
@@ -1,0 +1,22 @@
+{% extends "admin/index.html" %}
+{% load admin_chart_tags %}
+{% load static %}
+
+{% block extrastyle %}
+   {{ block.super }}
+   <link media="all" href="{% static 'nvd3/build/nv.d3.css' %}" type="text/css" rel="stylesheet" />
+   <script src="{% static "admin_tools/js/jquery/jquery.min.js" %}"></script>
+   <script src="{% static 'd3/d3.js' %}" type="text/javascript"></script>
+   <script src="{% static 'nvd3/build/nv.d3.js'%}" type="text/javascript"></script>
+   <script src="{% url 'admin-charts' %}" type="text/javascript"></script>
+   <style>
+   .admin_charts {
+       padding: 20px 40px;
+   }
+   </style>
+{% endblock %}
+
+{% block footer %}
+   {% chart_containers %}
+   {{ block.super }}
+{% endblock %}

--- a/admin_tools_stats/templates/admin_tools/dashboard/dashboard.html
+++ b/admin_tools_stats/templates/admin_tools/dashboard/dashboard.html
@@ -1,44 +1,6 @@
 {% extends "admin_tools/dashboard/dashboard.html" %}
 
 {% block dashboard_scripts %}
-<script type="text/javascript">
-   var html_string = '<svg style="width:{{module.chart_width}};height:{{module.chart_height}}px;"></svg>';
-   function loadChart(interval, graph_key, select_box_value){
-      var function_name = "loadChart_" + interval + "_" + graph_key;
-      if(select_box_value !== undefined && select_box_value != "") function_name += "_" + select_box_value;
-      if(function_name in window){
-         window[function_name]();
-      } else {
-         $("#" + interval + "__" + graph_key).empty().append(html_string);
-         url = "{% url 'chart-data' %}";
-         url += interval + "/" + graph_key + "/";
-         if(select_box_value !== undefined && select_box_value != "") url += select_box_value + "/";
-         $.getScript(url, function(){
-           window[function_name]();
-         });
-      };
-   }
-   function defer(method) {
-       if (window.jQuery && window.nv) {
-           method();
-       } else {
-           setTimeout(function() { defer(method) }, 50);
-       }
-   }
-   defer( function(){
-      function loadAnchor(){
-         var href = $(this).attr('href') || $(this).closest('.dashboard-module').attr('id');
-         var select_box_value = $(this).children("option:selected").attr('value');
-         href = href.replace('#', '').replace('module_', '').split("__");
-         var interval = href[0], graph_key = href[1];
-         loadChart(interval, graph_key, select_box_value);
-      }
-
-      $('a.ui-tabs-anchor').click(loadAnchor);
-      $('.dynamic_criteria_select_box').change(loadAnchor);
-      //TODO: init only visible modules - it is a bit tricky, because they are visible on page load
-      $('.dashboard-module:visible').find('li.ui-tabs-active').children('a.ui-tabs-anchor').each(loadAnchor)
-   });
-</script>
+<script src="{% url 'admin-charts' %}" type="text/javascript"></script>
 {{ block.super }}
 {% endblock %}

--- a/admin_tools_stats/templates/admin_tools/dashboard/dashboard.html
+++ b/admin_tools_stats/templates/admin_tools/dashboard/dashboard.html
@@ -1,0 +1,44 @@
+{% extends "admin_tools/dashboard/dashboard.html" %}
+
+{% block dashboard_scripts %}
+<script type="text/javascript">
+   var html_string = '<svg style="width:{{module.chart_width}};height:{{module.chart_height}}px;"></svg>';
+   function loadChart(interval, graph_key, select_box_value){
+      var function_name = "loadChart_" + interval + "_" + graph_key;
+      if(select_box_value !== undefined && select_box_value != "") function_name += "_" + select_box_value;
+      if(function_name in window){
+         window[function_name]();
+      } else {
+         $("#" + interval + "__" + graph_key).empty().append(html_string);
+         url = "{% url 'chart-data' %}";
+         url += interval + "/" + graph_key + "/";
+         if(select_box_value !== undefined && select_box_value != "") url += select_box_value + "/";
+         $.getScript(url, function(){
+           window[function_name]();
+         });
+      };
+   }
+   function defer(method) {
+       if (window.jQuery && window.nv) {
+           method();
+       } else {
+           setTimeout(function() { defer(method) }, 50);
+       }
+   }
+   defer( function(){
+      function loadAnchor(){
+         var href = $(this).attr('href') || $(this).closest('.dashboard-module').attr('id');
+         var select_box_value = $(this).children("option:selected").attr('value');
+         href = href.replace('#', '').replace('module_', '').split("__");
+         var interval = href[0], graph_key = href[1];
+         loadChart(interval, graph_key, select_box_value);
+      }
+
+      $('a.ui-tabs-anchor').click(loadAnchor);
+      $('.dynamic_criteria_select_box').change(loadAnchor);
+      //TODO: init only visible modules - it is a bit tricky, because they are visible on page load
+      $('.dashboard-module:visible').find('li.ui-tabs-active').children('a.ui-tabs-anchor').each(loadAnchor)
+   });
+</script>
+{{ block.super }}
+{% endblock %}

--- a/admin_tools_stats/templates/admin_tools/dashboard/dashboard.html
+++ b/admin_tools_stats/templates/admin_tools/dashboard/dashboard.html
@@ -1,6 +1,0 @@
-{% extends "admin_tools/dashboard/dashboard.html" %}
-
-{% block dashboard_scripts %}
-<script src="{% url 'admin-charts' %}" type="text/javascript"></script>
-{{ block.super }}
-{% endblock %}

--- a/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
+++ b/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
@@ -31,11 +31,13 @@ function defer(method) {
 }
 
 defer( function(){
-   function loadAnchor(){
-      var data = $(this).closest('form.stateform');
-      loadChart(data);
-   }
+   $( document ).ready(function() {
+      function loadAnchor(){
+         var data = $(this).closest('form.stateform');
+         loadChart(data);
+      }
 
-   $('.chart-input').closest('form.stateform').change(loadAnchor);
-   $('form.stateform').each(loadAnchor)
+      $('.chart-input').closest('form.stateform').change(loadAnchor);
+      $('form.stateform').each(loadAnchor);
+   });
 });

--- a/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
+++ b/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
@@ -1,0 +1,41 @@
+
+var chart_scripts = {};
+
+function loadChart(data){
+   data_str = data.serialize();
+   var graph_key = data.children(".hidden_graph_key").first().val();
+
+   if(data_str in chart_scripts){
+      console.log("run " + data_str);
+      chart_scripts[data_str]();
+   } else {
+      url = "{% url 'chart-data' %}" + graph_key + "/";
+      $.ajax({
+         dataType: "script",
+         'url': url,
+         'data': data.serialize(),
+         success: function(){
+            console.log("call " + data_str);
+            chart_scripts[data_str] = loadChartScript;
+         }
+      });
+   };
+}
+
+function defer(method) {
+    if (window.jQuery && window.nv) {
+        method();
+    } else {
+        setTimeout(function() { defer(method) }, 50);
+    }
+}
+
+defer( function(){
+   function loadAnchor(){
+      var data = $(this).closest('form.stateform');
+      loadChart(data);
+   }
+
+   $('.chart-input').closest('form.stateform').change(loadAnchor);
+   $('form.stateform').each(loadAnchor)
+});

--- a/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
+++ b/admin_tools_stats/templates/admin_tools_stats/admin_charts.js
@@ -1,9 +1,9 @@
 
+var html_string = '<svg style="width:{{chart_width}};height:{{chart_height}}px;"></svg>';
 var chart_scripts = {};
 
-function loadChart(data){
+function loadChart(data, graph_key){
    data_str = data.serialize();
-   var graph_key = data.children(".hidden_graph_key").first().val();
 
    if(data_str in chart_scripts){
       console.log("run " + data_str);
@@ -34,10 +34,14 @@ defer( function(){
    $( document ).ready(function() {
       function loadAnchor(){
          var data = $(this).closest('form.stateform');
-         loadChart(data);
+         var graph_key = data.children(".hidden_graph_key").first().val();
+         if($(this).hasClass('select_box_chart_type') || $(this).hasClass('stateform')){
+            $("#chart_container_" + graph_key).empty().append(html_string);
+         };
+         loadChart(data, graph_key);
       }
 
-      $('.chart-input').closest('form.stateform').change(loadAnchor);
+      $('.chart-input').change(loadAnchor);
       $('form.stateform').each(loadAnchor);
    });
 });

--- a/admin_tools_stats/templates/admin_tools_stats/chart_containers.html
+++ b/admin_tools_stats/templates/admin_tools_stats/chart_containers.html
@@ -6,7 +6,7 @@
        {% csrf_token %}
        {{ chart.get_control_form }}
     </form>
-    <div id="chart_container_{{ chart.graph_key }}"><svg style="width:100%;height:300px;" class="nvd3-svg" height="450"></svg></div>
+    <div id="chart_container_{{ chart.graph_key }}"><svg style="width:100%;height:300px;" height="450"></svg></div>
     <br/>
 </div>
 {% endfor %}

--- a/admin_tools_stats/templates/admin_tools_stats/chart_containers.html
+++ b/admin_tools_stats/templates/admin_tools_stats/chart_containers.html
@@ -1,0 +1,13 @@
+<div class="admin_charts">
+{% for chart in charts %}
+<div id="chart_{{ chart.graph_key }}">
+    <h3>{{ chart.graph_title }}</h3>
+    <form class="stateform" action="." method="POST" enctype="multipart/form-data">
+       {% csrf_token %}
+       {{ chart.get_control_form }}
+    </form>
+    <div id="chart_container_{{ chart.graph_key }}"><svg style="width:100%;height:300px;" class="nvd3-svg" height="450"></svg></div>
+    <br/>
+</div>
+{% endfor %}
+</div>

--- a/admin_tools_stats/templates/admin_tools_stats/chart_data.html
+++ b/admin_tools_stats/templates/admin_tools_stats/chart_data.html
@@ -1,0 +1,4 @@
+{% load nvd3_tags %}
+function loadChart_{{ module.interval }}_{{ module.graph_key}}{% if module.select_box_value %}_{{ module.select_box_value }}{% endif %}(){
+   {% load_chart module.chart_type module.values module.chart_container module.extra %}
+}

--- a/admin_tools_stats/templates/admin_tools_stats/chart_data.html
+++ b/admin_tools_stats/templates/admin_tools_stats/chart_data.html
@@ -1,5 +1,5 @@
 {% load nvd3_tags %}
 function loadChartScript(){
-   {% load_chart module.chart_type module.values module.chart_container module.extra %}
+   {% load_chart chart_type values chart_container extra %}
 };
 loadChartScript();

--- a/admin_tools_stats/templates/admin_tools_stats/chart_data.html
+++ b/admin_tools_stats/templates/admin_tools_stats/chart_data.html
@@ -1,4 +1,5 @@
 {% load nvd3_tags %}
-function loadChart_{{ module.interval }}_{{ module.graph_key}}{% if module.select_box_value %}_{{ module.select_box_value }}{% endif %}(){
+function loadChartScript(){
    {% load_chart module.chart_type module.values module.chart_container module.extra %}
-}
+};
+loadChartScript();

--- a/admin_tools_stats/templates/admin_tools_stats/modules/chart.html
+++ b/admin_tools_stats/templates/admin_tools_stats/modules/chart.html
@@ -6,10 +6,6 @@
 {% endif %}
 
 {% block module_content %}
-    {# Jquery CDN : Needed when using jquery_on_ready=True #}
-    {% if module.extra.jquery_on_ready %}
-        <script src="{% static "admin_tools/js/jquery/jquery.min.js" %}"></script>
-    {% endif %}
     {% if module.require_chart_jscss %}
         <link media="all" href="{% static 'nvd3/build/nv.d3.css' %}" type="text/css" rel="stylesheet" />
         <script src="{% static 'd3/d3.js' %}" type="text/javascript"></script>

--- a/admin_tools_stats/templates/admin_tools_stats/modules/chart.html
+++ b/admin_tools_stats/templates/admin_tools_stats/modules/chart.html
@@ -16,40 +16,6 @@
         <script src="{% static 'nvd3/build/nv.d3.js'%}" type="text/javascript"></script>
     {% endif %}
 
-    <script type="text/javascript">
-        var init_value = true;
-        var html_string = '<svg style="width:{{module.chart_width}};height:{{module.chart_height}}px;"></svg>';
-
-        function defer(method) {
-            if (window.jQuery && window.nv) {
-                method();
-            } else {
-                setTimeout(function() { defer(method) }, 50);
-            }
-        }
-
-        defer( function(){
-            function loadChart_{{ module.interval }}_{{ module.graph_key}}(){
-                {% load_chart module.chart_type module.values module.chart_container module.extra %}
-            }
-
-            $('body').on('click', 'a.ui-tabs-anchor[href$={{ module.interval }}_{{ module.graph_key}}]', 'click', function(event)
-            {
-                var href_val = event.target.hash;
-                if(href_val.indexOf('{{ module.interval }}_{{ module.graph_key}}' ) != -1)
-                {
-                    $('#{{module.chart_container}}').empty().append(html_string);
-                    loadChart_{{ module.interval }}_{{ module.graph_key}}();
-                }
-                init_value = false;
-            });
-            // init
-            if(init_value){
-                loadChart_{{ module.interval }}_{{ module.graph_key}}();
-            };
-        });
-    </script>
-
     {% if module.form_field %}
         <form class="stateform" action="." method="POST" enctype="multipart/form-data">{% csrf_token %}
             {{ module.form_field }}

--- a/admin_tools_stats/templatetags/admin_chart_tags.py
+++ b/admin_tools_stats/templatetags/admin_chart_tags.py
@@ -1,0 +1,16 @@
+
+from django import template
+from django.template.loader import render_to_string
+
+from ..modules import get_active_graph
+
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def chart_containers(context):
+    import pprint
+    pprint.pprint(get_active_graph())
+    context['charts'] = get_active_graph()
+    return render_to_string("admin_tools_stats/chart_containers.html", context.flatten())

--- a/admin_tools_stats/templatetags/admin_chart_tags.py
+++ b/admin_tools_stats/templatetags/admin_chart_tags.py
@@ -11,6 +11,6 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def chart_containers(context):
-    context['charts'] = get_active_graph()
     if 'admin_tools.dashboard' not in settings.INSTALLED_APPS:
+        context['charts'] = get_active_graph()
         return render_to_string("admin_tools_stats/chart_containers.html", context.flatten())

--- a/admin_tools_stats/templatetags/admin_chart_tags.py
+++ b/admin_tools_stats/templatetags/admin_chart_tags.py
@@ -1,6 +1,7 @@
 
 from django import template
 from django.template.loader import render_to_string
+from django.conf import settings
 
 from ..modules import get_active_graph
 
@@ -10,7 +11,6 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def chart_containers(context):
-    import pprint
-    pprint.pprint(get_active_graph())
     context['charts'] = get_active_graph()
-    return render_to_string("admin_tools_stats/chart_containers.html", context.flatten())
+    if 'admin_tools.dashboard' not in settings.INSTALLED_APPS:
+        return render_to_string("admin_tools_stats/chart_containers.html", context.flatten())

--- a/admin_tools_stats/urls.py
+++ b/admin_tools_stats/urls.py
@@ -1,0 +1,11 @@
+
+from django.urls import path
+
+from .views import ChartDataView
+
+
+urlpatterns = [
+    path('chart_data/', ChartDataView.as_view(), name='chart-data'),  #Only to get the base address in template, will need parameters
+    path('chart_data/<str:interval>/<str:graph_key>/', ChartDataView.as_view(), name='chart-data'),
+    path('chart_data/<str:interval>/<str:graph_key>/<str:select_box_value>/', ChartDataView.as_view(), name='chart-data'),
+]

--- a/admin_tools_stats/urls.py
+++ b/admin_tools_stats/urls.py
@@ -1,11 +1,11 @@
 
 from django.urls import path
 
-from .views import ChartDataView
+from .views import AdminChartsView, ChartDataView
 
 
 urlpatterns = [
+    path('admin_charts.js', AdminChartsView.as_view(content_type='application/javascript'), name='admin-charts'),
     path('chart_data/', ChartDataView.as_view(), name='chart-data'),  #Only to get the base address in template, will need parameters
-    path('chart_data/<str:interval>/<str:graph_key>/', ChartDataView.as_view(), name='chart-data'),
-    path('chart_data/<str:interval>/<str:graph_key>/<str:select_box_value>/', ChartDataView.as_view(), name='chart-data'),
+    path('chart_data/<str:graph_key>/', ChartDataView.as_view(), name='chart-data'),
 ]

--- a/admin_tools_stats/views.py
+++ b/admin_tools_stats/views.py
@@ -13,8 +13,13 @@ from .models import DashboardStats
 class AdminChartsView(TemplateView):
     template_name = 'admin_tools_stats/admin_charts.js'
 
+    def get_context_data(self, *args, interval=None, graph_key=None, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context['chart_height'] = 300
+        context['chart_width'] = '100%'
+        return context
 
-chart_type = 'discreteBarChart'
+
 interval_dateformat_map = {
     'years': ("%Y", "%Y"),
     'weeks': ("%b %Y", "%b"),
@@ -33,6 +38,7 @@ class ChartDataView(TemplateView):
     def get_context_data(self, *args, interval=None, graph_key=None, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         interval = self.request.GET.get('select_box_interval', interval)
+        context['chart_type'] = self.request.GET.get('select_box_chart_type', interval)
         try:
             time_since = datetime.strptime(self.request.GET.get('time_since', None), '%Y-%m-%d')
             time_until = datetime.strptime(self.request.GET.get('time_until', None), '%Y-%m-%d')
@@ -71,5 +77,4 @@ class ChartDataView(TemplateView):
         }
 
         context['chart_container'] = "chart_container_" + graph_key
-        context['chart_type'] = chart_type
         return context

--- a/admin_tools_stats/views.py
+++ b/admin_tools_stats/views.py
@@ -1,6 +1,8 @@
 import time
 from datetime import datetime
 
+from django.contrib.auth.decorators import user_passes_test
+from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
 import pytz
@@ -22,6 +24,7 @@ interval_dateformat_map = {
 }
 
 
+@method_decorator(user_passes_test(lambda u: u.is_superuser), name='dispatch')
 class ChartDataView(TemplateView):
     template_name = 'admin_tools_stats/chart_data.html'
 

--- a/admin_tools_stats/views.py
+++ b/admin_tools_stats/views.py
@@ -1,15 +1,25 @@
-import pytz
+import time
 from datetime import datetime
 
-from django.conf import settings
-from django.utils import timezone
-from django.utils.module_loading import import_string
 from django.views.generic import TemplateView
-from django.utils.timezone import now
+
+import pytz
+
+from .models import DashboardStats
 
 
 class AdminChartsView(TemplateView):
     template_name = 'admin_tools_stats/admin_charts.js'
+
+
+chart_type = 'discreteBarChart'
+interval_dateformat_map = {
+    'years': ("%Y", "%Y"),
+    'weeks': ("%b %Y", "%b"),
+    'months': ("%b %Y", "%b"),
+    'days': ("%a %d %b %Y", "%a"),
+    'hours': ("%a %d %b %Y %H:%S", "%H"),
+}
 
 
 class ChartDataView(TemplateView):
@@ -20,19 +30,43 @@ class ChartDataView(TemplateView):
     def get_context_data(self, *args, interval=None, graph_key=None, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         interval = self.request.GET.get('select_box_interval', interval)
-        time_since = datetime.strptime(self.request.GET.get('time_since', None), '%Y-%m-%d')
-        time_since = pytz.utc.localize(time_since)
-        time_until = datetime.strptime(self.request.GET.get('time_until', None), '%Y-%m-%d')
-        time_until = pytz.utc.localize(time_until)
-        DashboardChart = import_string(getattr(settings, 'ADMIN_TOOLS_STATS_CHART_APP', 'admin_tools_stats.modules.DashboardChart'))
-        module = DashboardChart(
-            'today'.title(),
-            interval=interval,
-            time_since=time_since,
-            time_until=time_until,
-            require_chart_jscss=False,
-            graph_key=graph_key,
-        )
-        module.init_with_context_ajax({'request': self.request})
-        context['module'] = module
+        try:
+            time_since = datetime.strptime(self.request.GET.get('time_since', None), '%Y-%m-%d')
+            time_until = datetime.strptime(self.request.GET.get('time_until', None), '%Y-%m-%d')
+        except ValueError:
+            return context
+
+        # TODO: current timezone doesn't work for years with queryset stats
+        # current_tz = timezone.get_current_timezone()
+        current_tz = pytz.utc
+        time_since = current_tz.localize(time_since)
+        time_until = current_tz.localize(time_until)
+        time_until = time_until.replace(hour=23, minute=59)
+
+        dashboard_stats = DashboardStats.objects.get(graph_key=graph_key)
+        data = dashboard_stats.get_time_series(self.request, time_since, time_until, interval)
+        xdata = []
+        ydata = []
+        for data_date in data:
+            start_time = int(time.mktime(data_date[0].timetuple()) * 1000)
+            xdata.append(start_time)
+            ydata.append(data_date[1])
+
+        context['extra'] = {
+            'x_is_date': True,
+            'tag_script_js': False,
+        }
+
+        tooltip_date_format, context['extra']['x_axis_format'] = interval_dateformat_map[interval]
+
+        extra_serie = {"tooltip": {"y_start": "", "y_end": ""},
+                       "date_format": tooltip_date_format}
+
+        context['values'] = {
+            'x': xdata,
+            'name1': interval, 'y1': ydata, 'extra1': extra_serie,
+        }
+
+        context['chart_container'] = "chart_container_" + graph_key
+        context['chart_type'] = chart_type
         return context

--- a/admin_tools_stats/views.py
+++ b/admin_tools_stats/views.py
@@ -1,6 +1,15 @@
+import pytz
+from datetime import datetime
+
 from django.conf import settings
+from django.utils import timezone
 from django.utils.module_loading import import_string
 from django.views.generic import TemplateView
+from django.utils.timezone import now
+
+
+class AdminChartsView(TemplateView):
+    template_name = 'admin_tools_stats/admin_charts.js'
 
 
 class ChartDataView(TemplateView):
@@ -8,15 +17,21 @@ class ChartDataView(TemplateView):
 
     cache_cache_name = "pages"
 
-    def get_context_data(self, *args, interval=None, graph_key=None, select_box_value='', **kwargs):
+    def get_context_data(self, *args, interval=None, graph_key=None, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        interval = self.request.GET.get('select_box_interval', interval)
+        time_since = datetime.strptime(self.request.GET.get('time_since', None), '%Y-%m-%d')
+        time_since = pytz.utc.localize(time_since)
+        time_until = datetime.strptime(self.request.GET.get('time_until', None), '%Y-%m-%d')
+        time_until = pytz.utc.localize(time_until)
         DashboardChart = import_string(getattr(settings, 'ADMIN_TOOLS_STATS_CHART_APP', 'admin_tools_stats.modules.DashboardChart'))
         module = DashboardChart(
             'today'.title(),
             interval=interval,
+            time_since=time_since,
+            time_until=time_until,
             require_chart_jscss=False,
             graph_key=graph_key,
-            **{"select_box_" + graph_key: select_box_value},
         )
         module.init_with_context_ajax({'request': self.request})
         context['module'] = module

--- a/admin_tools_stats/views.py
+++ b/admin_tools_stats/views.py
@@ -22,8 +22,8 @@ class AdminChartsView(TemplateView):
 
 interval_dateformat_map = {
     'years': ("%Y", "%Y"),
-    'weeks': ("%b %Y", "%b"),
     'months': ("%b %Y", "%b"),
+    'weeks': ("%a %d %b %Y", "%W"),
     'days': ("%a %d %b %Y", "%a"),
     'hours': ("%a %d %b %Y %H:%S", "%H"),
 }

--- a/admin_tools_stats/views.py
+++ b/admin_tools_stats/views.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.utils.module_loading import import_string
+from django.views.generic import TemplateView
+
+
+class ChartDataView(TemplateView):
+    template_name = 'admin_tools_stats/chart_data.html'
+
+    cache_cache_name = "pages"
+
+    def get_context_data(self, *args, interval=None, graph_key=None, select_box_value='', **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        DashboardChart = import_string(getattr(settings, 'ADMIN_TOOLS_STATS_CHART_APP', 'admin_tools_stats.modules.DashboardChart'))
+        module = DashboardChart(
+            'today'.title(),
+            interval=interval,
+            require_chart_jscss=False,
+            graph_key=graph_key,
+            **{"select_box_" + graph_key: select_box_value},
+        )
+        module.init_with_context_ajax({'request': self.request})
+        context['module'] = module
+        return context

--- a/docs/source/installation-overview.rst
+++ b/docs/source/installation-overview.rst
@@ -38,7 +38,13 @@ Configuration
     INSTALLED_APPS = (
         'admin_tools_stats',
         'django_nvd3',
+        ...
+        'admin_tools.dashboard',  # This should be after admin_tools_stats
     )
+
+   If you have overriden `DashboardChart` module, you will have to set it's path in your settings::
+
+   ADMIN_TOOLS_STATS_CHART_APP = 'admin_dashboard.dashboard_charts.YearDashboardChart'
 
 - Add the following code to your file dashboard.py::
 
@@ -64,6 +70,13 @@ Configuration
                 kwargs[key] = context['request'].POST[key]
 
         self.children.append(DashboardCharts(**kwargs))
+
+- Register stats views in your `urls.py`::
+
+  from django.urls import path
+  urlpatterns = [
+      path('admin_tools_stats/', include('admin_tools_stats.urls')),
+  ]
 
 - To create the tables needed by Django-admin-tools-stats, run the following command::
 

--- a/docs/source/installation-overview.rst
+++ b/docs/source/installation-overview.rst
@@ -42,13 +42,9 @@ Configuration
         'admin_tools.dashboard',  # This should be after admin_tools_stats
     )
 
-   If you have overriden `DashboardChart` module, you will have to set it's path in your settings::
-
-   ADMIN_TOOLS_STATS_CHART_APP = 'admin_dashboard.dashboard_charts.YearDashboardChart'
-
 - Add the following code to your file dashboard.py::
 
-    from admin_tools_stats.modules import DashboardCharts, get_active_graph
+    from admin_tools_stats.modules import DashboardChart, get_active_graph
 
     # append an app list module for "Country_prefix"
     self.children.append(modules.AppList(
@@ -69,7 +65,7 @@ Configuration
             if key.startswith('select_box_'):
                 kwargs[key] = context['request'].POST[key]
 
-        self.children.append(DashboardCharts(**kwargs))
+        self.children.append(DashboardChart(**kwargs))
 
 - Register stats views in your `urls.py`::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-python-dateutil>=2.0
 django-jsonfield>=0.9.2
 django-qsstats-magic>=0.7.2
-djcacheutils>=3.0.0
-django-admin-tools>=0.5.1
 django-nvd3>=0.5.0
 django-bower

--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,13 @@ def parse_dependency_links(file_name):
 
 
 setup(
-    name='django-admin-tools-stats',
+    name='django-admin-charts',
     version=admin_tools_stats.__version__,
-    description='django-admin-tools-stats - Django-admin module to create charts and stats in your dashboard',
+    description='django-admin-charts - Easily configurable charts statistics for `django-admin` and `django-admin-tools`',
     long_description=read('README.rst'),
-    author='Belaid Arezqui',
-    author_email='areski@gmail.com',
-    url='https://github.com/areski/django-admin-tools-stats',
+    author='Petr Dlouhý',
+    author_email='petr.dlouhy@email.cz',
+    url='https://github.com/PetrDlouhy/django-admin-charts',
     include_package_data=True,
     zip_safe=False,
     package_dir={'admin_tools_stats': 'admin_tools_stats'},


### PR DESCRIPTION
This is proof of concept code which loads charts by Ajax.
It should fixes slow loading of admin page, has less load on server (since it is not loading other time intervals until they are requested), improve user experience, allow to change dynamic criteria without page reload, and in the future can offer many more dynamic features.

It will need some code cleaning, before it could be pulled in. Right now it renders the chart javascript by `django-nvd3`'s `load_chart` tag, which is not optimal, because it sends JavaScript code and maybe it would be better to send only data.
I am not sure if we can't use better library for this, or something.

TODO:
- [x] secure the view
- [x] rewrite dashboard.html to javascript file 
- [x] more live configuration less presets
- [x] clean the code
- [x] make possible to use this without `django-admin-tools`
- [x] more cleaning
- [x] update the docs
- [x] update tests
- [x] check caching/optimisation possibilities
- [x] don't use jQuery from `admin_tools` in `django-admin`
- [x] (if possible) simplify update steps and write them down, current are:
  - move `admin_tools_stats` in `INSTALLED_APPS` before `admin_tools` and `django.contrib.admin` (needed for overridden template)
  - add line to `urls.py`
  - change `DashboardCharts` to `DashboardChart` in dashboard definition (this is not needed, because dummy class is left)
  - check any overridden template from `admin_tools_stats` or `DashboardChart(s)` class that might interfere with the changes



Please post your suggestions.