### PR TITLE
Update bower dependencies in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,10 +73,10 @@ Configure
 
 
         BOWER_INSTALLED_APPS = (
-            'jquery#2.0.3',
-            'jquery-ui#~1.10.3',
-            'd3#3.3.6',
-            'nvd3#1.1.12-beta',
+            'jquery#3.4.1',
+            'jquery-ui#1.12.1',
+            'd3#3.3.13',
+            'nvd3#1.7.1',
         )
 
   - Add django-bower finder to your static file finders::


### PR DESCRIPTION
The path of nvd3 javacript in current version suggested by README doesn't correspond with path set in `chart.html`.
This is just quick fix of that problem without ambition to fix #14 or anything else.